### PR TITLE
Removing missing Eventbrite key

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ instructor: ["Jennifer Shelton", "Sue McClatchy", "Narayanan Raghupathy"]
 helper: ["Sue McClatchy", "Narayanan Raghupathy"]
 contact: susan.mcclatchy@jax.org
 etherpad: https://etherpad.mozilla.org/itv4FHBJSi
-eventbrite: "provide numerical key in double quotes"
+eventbrite: # not available
 ---
 <!--
   HEADER


### PR DESCRIPTION
If there isn't yet an Eventbrite key, the `eventbrite` field in the header should be empty or a comment - using `"something else in quotes"` causes an error, because our template tries to use the string `something else in quotes` to look up the Eventbrite registration widget.
